### PR TITLE
Need to output successful instances too

### DIFF
--- a/aws/ec2.py
+++ b/aws/ec2.py
@@ -362,6 +362,8 @@ def ssh(
                 logging.info(util.colors.green(' successes: ') + str(len(successes)))
                 logging.info(util.colors.red(' failures: ') + str(len(failures)))
             if failures:
+                for result in results:
+                    print(result)
                 sys.exit(1)
             else:
                 return results


### PR DESCRIPTION
If there are any instances that error out, only the error messages go onto stdout. This breaks some of our status scripts.